### PR TITLE
Yamanaka study2

### DIFF
--- a/yamanaka/chakra-ui/app/_components/Header.tsx
+++ b/yamanaka/chakra-ui/app/_components/Header.tsx
@@ -1,0 +1,33 @@
+import { Box, Flex, Heading, Text } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+export default function Header({ title }: { title?: string }) {
+  return (
+    <Box as='header'>
+      <Flex
+        bg='white'
+        color='gray.600'
+        minH={'60px'}
+        py={{ base: 2 }}
+        px={{ base: 4 }}
+        borderBottom={1}
+        borderStyle='solid'
+        borderColor='gray.200'
+        align='center'
+      >
+        <Flex flex={1} justify='space-between' maxW='6xl' mx='auto'>
+          <Heading as='h1' size='lg'>
+            <NextLink href='/'>Simple Utilities</NextLink>
+          </Heading>
+          {title ? (
+            <Heading as='h2' size='md' color='gray'>
+              {title}
+            </Heading>
+          ) : (
+            <></>
+          )}
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/yamanaka/chakra-ui/app/_components/UtilitiyCard.tsx
+++ b/yamanaka/chakra-ui/app/_components/UtilitiyCard.tsx
@@ -1,0 +1,25 @@
+import { Card, CardHeader, CardBody, CardFooter, Text, Heading } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+export default function UtilityCard({
+  title,
+  description,
+  link,
+}: {
+  title: string
+  description: string
+  link: string
+}) {
+  return (
+    <Card maxW='md'>
+      <CardHeader>
+        <NextLink href={link}>
+          <Heading>{title}</Heading>
+        </NextLink>
+      </CardHeader>
+      <CardBody>
+        <Text>{description}</Text>
+      </CardBody>
+    </Card>
+  )
+}

--- a/yamanaka/chakra-ui/app/_hooks/useCounters.tsx
+++ b/yamanaka/chakra-ui/app/_hooks/useCounters.tsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react'
+
+type CounterType = {
+  name: string
+  count: number
+}
+const initialCounter: CounterType = { name: 'counter', count: 0 }
+
+export default function useCounters() {
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState([initialCounter])
+
+  const load = () => {
+    const storedCounters = localStorage.getItem('counters')
+    try {
+      const counters: CounterType[] = storedCounters ? JSON.parse(storedCounters) : [initialCounter]
+      return counters
+    } catch (error) {
+      console.log('error occured when loading counter data in local storage')
+      console.log(error)
+      localStorage.setItem('counters', JSON.stringify([initialCounter]))
+      return [initialCounter]
+    }
+  }
+
+  useEffect(() => {
+    setData(load())
+    setLoading(false)
+  }, [])
+  useEffect(() => {
+    if (!loading) {
+      localStorage.setItem('counters', JSON.stringify(data))
+    }
+  }, [data, loading])
+
+  const nameUpdater = (key: number) => {
+    return (name: string) => {
+      if (data[key]) {
+        let change = data[key]
+        change.name = name
+        const newData = data.map((value, index) => {
+          return index == key ? change : value
+        })
+        setData(newData)
+      } else {
+        console.log('non existing counter is updated')
+      }
+    }
+  }
+
+  const countUpdater = (key: number) => {
+    return (count: number) => {
+      if (data[key]) {
+        let change = data[key]
+        change.count = count
+        const newData = data.map((value, index) => {
+          return index == key ? change : value
+        })
+        setData(newData)
+      } else {
+        console.log('non existing counter is updated')
+      }
+    }
+  }
+
+  const counterDeleter = (key: number) => {
+    return () => {
+      if (data[key]) {
+        const newData = data.filter((_, index) => index !== key)
+        setData(newData)
+      } else {
+        console.log('try to delete non exisiting counter')
+      }
+    }
+  }
+
+  const createCounter = () => {
+    const newData = data.concat(initialCounter)
+    setData(newData)
+  }
+
+  return { loading, data, nameUpdater, countUpdater, counterDeleter, createCounter }
+}

--- a/yamanaka/chakra-ui/app/counter/_components/Counter.tsx
+++ b/yamanaka/chakra-ui/app/counter/_components/Counter.tsx
@@ -13,47 +13,33 @@ import {
   Center,
   CloseButton,
 } from '@chakra-ui/react'
-import { useState, useEffect } from 'react'
 import TextareaAutosize from 'react-textarea-autosize'
 
-export default function Counter() {
-  const [count, setCount] = useState(0)
-  const [name, setName] = useState('カウンター')
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    console.log('loading strage...')
-    const storedCounter = localStorage.getItem('counter')
-    if (storedCounter != null) {
-      try {
-        const counter = JSON.parse(storedCounter)
-        if (Object.hasOwn(counter, 'name')) {
-          console.log(typeof counter.name)
-          if (typeof counter.name == 'string') setName(counter.name)
-        }
-        if (Object.hasOwn(counter, 'count')) {
-          if (typeof counter.count == 'number') setCount(counter.count)
-        }
-      } catch {
-        console.log('counter in localstrage is not correct JSON string')
-      }
-    }
-    setLoading(false)
-  }, [])
-  useEffect(() => {
-    if (loading == false)
-      localStorage.setItem('counter', JSON.stringify({ name: name, count: count }))
-  }, [count, name])
+export default function Counter({
+  count,
+  name,
+  loading,
+  setCount,
+  setName,
+  onDelete,
+}: {
+  count: number
+  name: string
+  loading: boolean
+  setCount: (count: number) => void
+  setName: (name: string) => void
+  onDelete: () => void
+}) {
   return (
     <Card margin={5} minW={244} maxW={244}>
       <CardHeader>
         <Skeleton isLoaded={!loading}>
           <HStack justifyContent='space-between' alignItems='top'>
-            <Editable value={name} onChange={(s) => setName(s)} flex={1}>
+            <Editable value={name} onChange={setName} flex={1}>
               <EditablePreview width='100%' wordBreak='break-all' />
               <EditableTextarea as={TextareaAutosize} width='100%' resize='none' minRows={1} />
             </Editable>
-            <CloseButton />
+            <CloseButton onClick={onDelete} />
           </HStack>
         </Skeleton>
       </CardHeader>

--- a/yamanaka/chakra-ui/app/counter/_components/CounterList.tsx
+++ b/yamanaka/chakra-ui/app/counter/_components/CounterList.tsx
@@ -1,11 +1,28 @@
+'use client'
 import Counter from './Counter'
-import { Stack } from '@chakra-ui/react'
+import { Stack, Button, Flex } from '@chakra-ui/react'
+import useCounters from '@/app/_hooks/useCounters'
 
 export default function CounterList() {
+  const { loading, data, nameUpdater, countUpdater, counterDeleter, createCounter } = useCounters()
   return (
     <Stack direction={['column', 'row']} wrap='wrap'>
-      <Counter />
-      <Counter />
+      {data.map((value, index) => (
+        <Counter
+          key={index}
+          count={value.count}
+          name={value.name}
+          loading={loading}
+          setCount={countUpdater(index)}
+          setName={nameUpdater(index)}
+          onDelete={counterDeleter(index)}
+        />
+      ))}
+      <Flex minH={272} alignItems='center'>
+        <Button ml={8} onClick={createCounter}>
+          +
+        </Button>
+      </Flex>
     </Stack>
   )
 }

--- a/yamanaka/chakra-ui/app/counter/layout.tsx
+++ b/yamanaka/chakra-ui/app/counter/layout.tsx
@@ -1,9 +1,15 @@
 import { Metadata } from 'next'
+import Header from '@/app/_components/Header'
 
 export const metadata: Metadata = {
   title: 'カウンター',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>
+  return (
+    <>
+      <Header title='カウンター' />
+      {children}
+    </>
+  )
 }

--- a/yamanaka/chakra-ui/app/page.tsx
+++ b/yamanaka/chakra-ui/app/page.tsx
@@ -1,95 +1,18 @@
-import Image from 'next/image'
-import styles from './page.module.css'
+import Header from './_components/Header'
+import UtilityCard from './_components/UtilitiyCard'
+import { Stack } from '@chakra-ui/react'
 
 export default function Home() {
   return (
-    <main className={styles.main}>
-      <div className={styles.description}>
-        <p>
-          Get started by editing&nbsp;
-          <code className={styles.code}>app/page.tsx</code>
-        </p>
-        <div>
-          <a
-            href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            By{' '}
-            <Image
-              src="/vercel.svg"
-              alt="Vercel Logo"
-              className={styles.vercelLogo}
-              width={100}
-              height={24}
-              priority
-            />
-          </a>
-        </div>
-      </div>
-
-      <div className={styles.center}>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js Logo"
-          width={180}
-          height={37}
-          priority
+    <>
+      <Header />
+      <Stack m={8}>
+        <UtilityCard
+          title='カウンター'
+          description='数を数えることができます。カウンターを複数使うこともできます。状態はブラウザに保存されます。'
+          link='/counter'
         />
-      </div>
-
-      <div className={styles.grid}>
-        <a
-          href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2>
-            Docs <span>-&gt;</span>
-          </h2>
-          <p>Find in-depth information about Next.js features and API.</p>
-        </a>
-
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2>
-            Learn <span>-&gt;</span>
-          </h2>
-          <p>Learn about Next.js in an interactive course with&nbsp;quizzes!</p>
-        </a>
-
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2>
-            Templates <span>-&gt;</span>
-          </h2>
-          <p>Explore the Next.js 13 playground.</p>
-        </a>
-
-        <a
-          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2>
-            Deploy <span>-&gt;</span>
-          </h2>
-          <p>
-            Instantly deploy your Next.js site to a shareable URL with Vercel.
-          </p>
-        </a>
-      </div>
-    </main>
+      </Stack>
+    </>
   )
 }

--- a/yamanaka/chakra-ui/tsconfig.json
+++ b/yamanaka/chakra-ui/tsconfig.json
@@ -20,7 +20,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["."]
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
# 内容

### 言語／フレームワーク
- ChakraUI
- React

### 勉強時間（※大体でOK）

合計4.5時間

### 勉強内容

- カウンターの追加削除機能の追加
- カウンターの状態保存を複数に対応
  - useCountersというカスタムフックを作成し利用してみた
- ヘッダーとトップページの作成

### 次勉強するもの

- カウンターを削除する際に警告を出す
- ツールの説明で改行を反映するようにする
- ToDoリストやタイマー等のツールを作成してみる


# 感想
### 有用と思ったもの・意外だったもの
- breeze-nextでは、認証のためにカスタムフックが用いられていた。カスタムフックについて理解するために、ローカルストレージからの読み込みをカスタムフックを作成して行ってみた。コンポーネント内に書くフックの量が減り、すっきりした。


### 苦戦したもの
- counterコンポーネントにuseStateを残したまま実装すると、無限ループが発生した。counterコンポーネントにpropsで必要な値を渡すことで無限ループが解消した。
