### PR TITLE
ポリシー作成

### DIFF
--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/CommentController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/CommentController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Comment;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CommentController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request, String $commentable_type, String $commentable_id)
+    {
+        $this->authorize('create', Comment::class);
+
+        $validated = $request->validate([
+            'content' => ['required', 'max:500'],
+        ]);
+
+        Comment::create([
+            'user_id' => Auth::user()->id,
+            'commentable_type' => $commentable_type,
+            'commentable_id' => $commentable_id,
+            'content' => $validated['content'],
+        ]);
+
+        return response(null, 200);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Comment $comment)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Comment $comment)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Comment $comment)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Comment $comment)
+    {
+        //
+    }
+}

--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/PostController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/PostController.php
@@ -69,7 +69,8 @@ class PostController extends Controller
         $post->load([
             'comments' => [ 'likes' ], //Postコメントとそれぞれのコメントのいいね
             'likes', // Postのいいね
-            'tags' // Postのタグ
+            'tags', // Postのタグ,
+            'user.followers'
         ]);
 
         return response()->json(new PostResource($post));

--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/PostController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/PostController.php
@@ -98,6 +98,8 @@ class PostController extends Controller
      */
     public function destroy(Post $post)
     {
+        $this->authorize('delete', $post);
+
        $post->delete();
 
         return response(null, 200);

--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/PostController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/PostController.php
@@ -45,6 +45,8 @@ class PostController extends Controller
      */
     public function update(Request $request, Post $post)
     {
+        $this->authorize('update', $post);
+
         $validated = $request->validate([
             'content' => ['required', 'max:2200'],
         ]);

--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Resources/PostResource.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Resources/PostResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Auth;
 
 class PostResource extends JsonResource
 {
@@ -13,9 +14,7 @@ class PostResource extends JsonResource
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array
-    {
-        // return parent::toArray($request);
-        
+    {        
         return [
             'id' => $this->id,
             'author' => [
@@ -31,7 +30,8 @@ class PostResource extends JsonResource
             }),
             'likes' => $this->likes->map(function ($like) {
                 return $like->user_id;
-            })
+            }),
+            'canComment' => Auth::user()->can('comment', $this)
         ];
     }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
@@ -71,15 +71,4 @@ class User extends Authenticatable
     {
         return $this->hasMany(Comment::class);
     }
-
-    // ログインしているユーザーがこのユーザー(このUserモデルのひと)をフォローしているかどうか
-    // = ログインユーザーが、このモデルのユーザーのフォロワーであるか
-    public function isFollowing() 
-    {
-        $id = $this->id;
-
-        $isFollowing = Auth::user()->followers()->where('follower_id',$id)->first();
-
-        return $isFollowing;
-    }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Auth;
 
 class User extends Authenticatable
 {
@@ -69,5 +70,16 @@ class User extends Authenticatable
     public function comments()
     {
         return $this->hasMany(Comment::class);
+    }
+
+    // ログインしているユーザーがこのユーザー(このUserモデルのひと)をフォローしているかどうか
+    // = ログインユーザーが、このモデルのユーザーのフォロワーであるか
+    public function isFollowing() 
+    {
+        $id = $this->id;
+
+        $isFollowing = Auth::user()->followers()->where('follower_id',$id)->first();
+
+        return $isFollowing;
     }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
@@ -71,4 +71,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Comment::class);
     }
+
+    public function getIsAdminAttribute()
+    {
+        return $this->role_id == 1; // 1が管理者
+    }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Policies/CommentPolicy.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Policies/CommentPolicy.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Policies;
+
+use Illuminate\Auth\Access\Response;
+use App\Models\Comment;
+use App\Models\User;
+
+class CommentPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        if($user->is_following()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Comment $comment): bool
+    {
+        //
+    }
+}

--- a/kinoshita/practice-erd/instagram/laravel/app/Policies/CommentPolicy.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Policies/CommentPolicy.php
@@ -9,39 +9,12 @@ use App\Models\User;
 class CommentPolicy
 {
     /**
-     * Determine whether the user can view any models.
-     */
-    public function viewAny(User $user): bool
-    {
-        //
-    }
-
-    /**
-     * Determine whether the user can view the model.
-     */
-    public function view(User $user, Comment $comment): bool
-    {
-        //
-    }
-
-    /**
-     * Determine whether the user can create models.
-     */
-    public function create(User $user): bool
-    {
-        if($user->is_following()) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
      * Determine whether the user can update the model.
      */
     public function update(User $user, Comment $comment): bool
     {
-        //
+        // 自身のコメントなら編集できる
+        return $user->id == $comment->user_id;
     }
 
     /**
@@ -49,22 +22,7 @@ class CommentPolicy
      */
     public function delete(User $user, Comment $comment): bool
     {
-        //
-    }
-
-    /**
-     * Determine whether the user can restore the model.
-     */
-    public function restore(User $user, Comment $comment): bool
-    {
-        //
-    }
-
-    /**
-     * Determine whether the user can permanently delete the model.
-     */
-    public function forceDelete(User $user, Comment $comment): bool
-    {
-        //
+        // 管理者か、投稿した本人であれば、削除できる
+        return $user->is_admin || $user->id == $comment->user_id;
     }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
@@ -25,25 +25,12 @@ class PostPolicy
     public function update(User $user, Post $post): bool
     {
         // 自身の投稿なら編集できる
-        if($user->id == $post->user_id){
-            return true;
-        }  else {
-            return false;
-        }
+        return $user->id == $post->user_id;
     }
 
     public function delete(User $user, Post $post): bool
     {
-        // 管理者権限
-        if($user->role_id == 1) {
-            return true;
-        }
-
-        // 自身の投稿なら編集できる
-        if($user->id == $post->user_id){
-            return true;
-        }  else {
-            return false;
-        }
+        // 管理者か、投稿した本人であれば、削除できる
+        return $user->is_admin || $user->id == $post->user_id;
     }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use Illuminate\Auth\Access\Response;
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Post $post): bool
+    {
+        if($user->id == $post->user_id){
+            return true;
+        }  else {
+            return false;
+        }
+    }
+}

--- a/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
@@ -8,6 +8,20 @@ use App\Models\User;
 
 class PostPolicy
 {
+    public function comment(User $user, Post $post)
+    {
+        // 投稿をしたユーザーのフォロワー (Userモデルのコレクション)
+        $followers = $post->user->followers;
+
+        // ↑のフォロワーのリストの中に、（ログイン中の）ユーザーがいるか確認する
+        // いたら、ログイン中のユーザーは、この投稿をしたユーザーをフォローしている
+        $isFollowing = $followers->contains(function ($follower) use ($user) {
+            return $follower['id'] == $user->id;
+        });
+
+        return $isFollowing;
+    }
+
     public function update(User $user, Post $post): bool
     {
         // 自身の投稿なら編集できる

--- a/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Policies/PostPolicy.php
@@ -8,11 +8,24 @@ use App\Models\User;
 
 class PostPolicy
 {
-    /**
-     * Determine whether the user can update the model.
-     */
     public function update(User $user, Post $post): bool
     {
+        // 自身の投稿なら編集できる
+        if($user->id == $post->user_id){
+            return true;
+        }  else {
+            return false;
+        }
+    }
+
+    public function delete(User $user, Post $post): bool
+    {
+        // 管理者権限
+        if($user->role_id == 1) {
+            return true;
+        }
+
+        // 自身の投稿なら編集できる
         if($user->id == $post->user_id){
             return true;
         }  else {

--- a/kinoshita/practice-erd/instagram/laravel/app/Providers/AuthServiceProvider.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Providers/AuthServiceProvider.php
@@ -25,14 +25,7 @@ class AuthServiceProvider extends ServiceProvider
      * Register any authentication / authorization services.
      */
     public function boot(): void
-    {       
-        $this->registerPolicies(); // 要るか不明
-
-        Gate::define('isAdmin',function($user){
-           return $user->role == 1;
-
-        });
-
+    {
         Gate::guessPolicyNamesUsing(function (string $modelClass) {
             return Str::of($modelClass)->replace('App\Models', 'App\Policies').'Policy';
         });

--- a/kinoshita/practice-erd/instagram/laravel/app/Providers/AuthServiceProvider.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,12 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+
+use App\Models\Post;
+use App\Policies\PostPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        // Post::class => PostPolicy::class, // これでもいい
     ];
 
     /**
@@ -21,6 +26,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::guessPolicyNamesUsing(function (string $modelClass) {
+            return Str::of($modelClass)->replace('App\Models', 'App\Policies').'Policy';
+        });
     }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Providers/AuthServiceProvider.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Providers/AuthServiceProvider.php
@@ -25,7 +25,14 @@ class AuthServiceProvider extends ServiceProvider
      * Register any authentication / authorization services.
      */
     public function boot(): void
-    {
+    {       
+        $this->registerPolicies(); // 要るか不明
+
+        Gate::define('isAdmin',function($user){
+           return $user->role == 1;
+
+        });
+
         Gate::guessPolicyNamesUsing(function (string $modelClass) {
             return Str::of($modelClass)->replace('App\Models', 'App\Policies').'Policy';
         });

--- a/kinoshita/practice-erd/instagram/laravel/database/factories/PostFactory.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/factories/PostFactory.php
@@ -19,7 +19,7 @@ class PostFactory extends Factory
     {
         // 選ばれたユーザーの投稿を作る
         return [
-            'user_id' => User::factory()->create()->id,
+            'user_id' => User::factory(),
             'content' => fake()->realText(),
             'image_url' => fake()->imageUrl(),
         ];

--- a/kinoshita/practice-erd/instagram/laravel/database/factories/PostFactory.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/factories/PostFactory.php
@@ -19,7 +19,7 @@ class PostFactory extends Factory
     {
         // 選ばれたユーザーの投稿を作る
         return [
-            'user_id' => User::factory(),
+            'user_id' => User::factory()->create()->id,
             'content' => fake()->realText(),
             'image_url' => fake()->imageUrl(),
         ];

--- a/kinoshita/practice-erd/instagram/laravel/database/factories/UserFactory.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/factories/UserFactory.php
@@ -22,7 +22,7 @@ class UserFactory extends Factory
     {
         return [
             'username' => fake()->userName(),
-            'role_id' => 1,
+            'role_id' => 0, // ユーザー
             'first_name' => fake()->firstName(),
             'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
@@ -31,6 +31,15 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];
+    }
+
+    public function admin()
+    {
+        return $this->state(fn (array $attributes) => [
+            'role_id' => 1, // 管理者
+            'first_name' => "admin",
+            'last_name' => "!管理者!",
+        ]);
     }
 
     /**

--- a/kinoshita/practice-erd/instagram/laravel/database/factories/UserFactory.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/factories/UserFactory.php
@@ -22,6 +22,7 @@ class UserFactory extends Factory
     {
         return [
             'username' => fake()->userName(),
+            'role_id' => 1,
             'first_name' => fake()->firstName(),
             'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),

--- a/kinoshita/practice-erd/instagram/laravel/database/migrations/2023_12_03_053439_add_basic_columns_to_users_table.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/migrations/2023_12_03_053439_add_basic_columns_to_users_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->string('last_name');
             $table->string('first_name');
             $table->string('icon_url');
+            $table->integer('role_id')->default(1); // 0: 管理者, 1: ユーザー
         });
     }
 

--- a/kinoshita/practice-erd/instagram/laravel/database/migrations/2023_12_03_053439_add_basic_columns_to_users_table.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/migrations/2023_12_03_053439_add_basic_columns_to_users_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->string('last_name');
             $table->string('first_name');
             $table->string('icon_url');
-            $table->integer('role_id')->default(1); // 0: 管理者, 1: ユーザー
+            $table->integer('role_id')->default(0); // 0: ユーザー, 1: 管理者
         });
     }
 

--- a/kinoshita/practice-erd/instagram/laravel/database/seeders/DatabaseSeeder.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/seeders/DatabaseSeeder.php
@@ -24,6 +24,6 @@ class DatabaseSeeder extends Seeder
             )->create();
 
         // 管理者
-        User::factory(1)->create(['role_id' => 0]);
+        User::factory()->admin()->create();
     }
 }

--- a/kinoshita/practice-erd/instagram/laravel/database/seeders/DatabaseSeeder.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/seeders/DatabaseSeeder.php
@@ -15,12 +15,15 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        User::factory(5) // ユーザー五人
+        User::factory()
             ->has( 
             Post::factory(2) // 全員に２投稿ずつあり
                 ->hasComments(3) // 各投稿にコメント3個ある
                 ->hasLikes(2) // 各投稿にいいね2個ある
                 ->hasTags(2) // 各投稿にたぐ2個ある
             )->create();
+
+        // 管理者
+        User::factory(1)->create(['role_id' => 0]);
     }
 }

--- a/kinoshita/practice-erd/instagram/laravel/routes/api.php
+++ b/kinoshita/practice-erd/instagram/laravel/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CommentController;
 use App\Http\Controllers\LikeController;
 use App\Http\Controllers\PostController;
 use App\Models\Comment;
@@ -32,3 +33,8 @@ Route::group([
     Route::post('', 'store');
     Route::delete('', 'destroy');
 });
+
+Route::post(
+    '/comment/{commentable_type}/{commentable_id}', 
+    [CommentController::class, 'create']
+)->where('commentable_type', 'post|comment');


### PR DESCRIPTION
# 内容

### 言語／フレームワーク
- [x] Laravel
- [ ] NextJs
- [ ] React＋Typescript
- [ ] Reactのみ

### 勉強時間（※大体でOK）

合計6時間  (資料3時間くらい, 実装3時間)

### 勉強内容

例：Controller作りました・データベースに接続を果たせました

- 資料を読む (https://readouble.com/laravel/10.x/ja/authorization.html)
- 同様の実装をしている記事をみる 
  - https://trend-appsweb.com/myportfolio/?p=1422
  - https://biz.addisteria.com/profile-edit-policy/
- 投稿のポリシーを追加
- コメントを投稿する機能を、ポリシーつきで追加

### 次勉強するもの
- 認証 Auth->user()が使えないため


# 感想
### 有用と思ったもの・意外だったもの
- 認可を実装する仕組みが結構たくさんあると知りました gateとかpolicyとかmiddleware。今まではmiddlewareくらいしか知りませんでした。
- 全体的に認可を設定するのか、アクションごとに設定できるのかも柔軟に対応できそうと思いました


### 苦戦したもの
- gateとpolicyの使い分けが難しそうでした。
- 資料には、policyを使った方がより堅牢なアプリケーションになると書かれていましたが、gateがあれば、policyなくても認可できるくない？と感じてしまった。

### 楽しかったもの（※任意）
- 

