### PR TITLE
プロフィール画面　フォロー機能　追加

### DIFF
--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/FollowController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/FollowController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\Follower;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class FollowController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request, User $user)
+    {
+        $follow = Follower::where([
+            'user_id' => Auth::user()->id,
+            'follower_id' => $user->id
+        ])->get();
+
+        throw_if(
+            $follow,
+            'すでにフォローしています'
+        );
+
+        Follower::create([
+            'user_id' => Auth::user()->id,
+            'follower_id' => $user->id
+        ]);
+
+        return response(null, 200);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Request $request, User $user)
+    {
+        $follow = Follower::where([
+            'user_id' => Auth::user()->id,
+            'follower_id' => $user->id
+        ])->get();
+
+        throw_if(
+            !$follow,
+            'もうすでにフォローを外しています'
+        );
+
+        $follow->delete();
+
+        return response(null, 200);
+    }
+}

--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/ProfileController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/ProfileController.php
@@ -35,16 +35,22 @@ class ProfileController extends Controller
         $followersCount = count($user->followers->toArray());
         // フォロワー数
         $followeesCount = count($user->followees->toArray());
-        
-        // 認可はあとで
+
+        // ログイン中のユーザーをフォローしているかどうか
+        $isFollow = $user->is_follow;
 
         // 画像のリンク一覧
         // 投稿数はこの配列の要素数で分かる
-        $postImages = $user->posts->map(function (Post $post) {
-            return $post->image_url;
-        });
+        $postImages = $isFollow
+            ? $postImages = $user->posts->map(fn (Post $post) => $post->image_url)
+            : null; 
         
-        return response(null, 200);
+        return response()->json(compact([
+            'isFollow',
+            'followersCount',
+            'followeesCount',
+            'postImages'
+        ]));
     }
 
     /**

--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/ProfileController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\ProfileResource;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Request $request, User $user)
+    {
+        // フォロー数
+        $followersCount = count($user->followers->toArray());
+        // フォロワー数
+        $followeesCount = count($user->followees->toArray());
+        
+        // 認可はあとで
+
+        // 画像のリンク一覧
+        // 投稿数はこの配列の要素数で分かる
+        $postImages = $user->posts->map(function (Post $post) {
+            return $post->image_url;
+        });
+        
+        return response(null, 200);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/ProfileController.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Http/Controllers/ProfileController.php
@@ -36,16 +36,20 @@ class ProfileController extends Controller
         // フォロワー数
         $followeesCount = count($user->followees->toArray());
 
+        // 対象のユーザーのアカウントが鍵垢かどうか
+        $isPrivate = $user->is_private;
+
         // ログイン中のユーザーをフォローしているかどうか
         $isFollow = $user->is_follow;
 
         // 画像のリンク一覧
         // 投稿数はこの配列の要素数で分かる
-        $postImages = $isFollow
+        $postImages = $isPrivate
             ? $postImages = $user->posts->map(fn (Post $post) => $post->image_url)
             : null; 
         
         return response()->json(compact([
+            'isPrivate',
             'isFollow',
             'followersCount',
             'followeesCount',

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/Follower.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/Follower.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Follower extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $guarded = [
+        'id',
+    ];
+}

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
@@ -86,4 +86,9 @@ class User extends Authenticatable
     {
         return $this->role_id == 1; // 1が管理者
     }
+
+    public function getIsPrivateAttribute()
+    {
+        return $this->is_private == 1; // 1が鍵垢
+    }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
@@ -72,6 +72,16 @@ class User extends Authenticatable
         return $this->hasMany(Comment::class);
     }
 
+    // 対象のユーザーが、ログイン中のユーザーをフォローしているかどうか
+    public function getIsFollowAttribute()
+    {
+        $loginUser = Auth::user();
+        
+        return $this->followees->contains(function ($followee) use ($loginUser) {
+            return $followee->id == $loginUser->id;
+        });
+    }
+
     public function getIsAdminAttribute()
     {
         return $this->role_id == 1; // 1が管理者

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
@@ -86,9 +86,4 @@ class User extends Authenticatable
     {
         return $this->role_id == 1; // 1が管理者
     }
-
-    public function getIsPrivateAttribute()
-    {
-        return $this->is_private == 1; // 1が鍵垢
-    }
 }

--- a/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
+++ b/kinoshita/practice-erd/instagram/laravel/app/Models/User.php
@@ -10,6 +10,8 @@ use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
 
+use function PHPUnit\Framework\isEmpty;
+
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
@@ -75,10 +77,10 @@ class User extends Authenticatable
     // 対象のユーザーが、ログイン中のユーザーをフォローしているかどうか
     public function getIsFollowAttribute()
     {
-        $loginUser = Auth::user();
+        if($this->followees->isEmpty()) return false;
         
-        return $this->followees->contains(function ($followee) use ($loginUser) {
-            return $followee->id == $loginUser->id;
+        return $this->followees->contains(function ($followee) {
+            return $followee->id == Auth::user()->id;
         });
     }
 

--- a/kinoshita/practice-erd/instagram/laravel/database/factories/UserFactory.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/factories/UserFactory.php
@@ -23,6 +23,7 @@ class UserFactory extends Factory
         return [
             'username' => fake()->userName(),
             'role_id' => 0, // ユーザー
+            'is_private' => 0, // 鍵垢ではない
             'first_name' => fake()->firstName(),
             'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
@@ -31,6 +32,13 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];
+    }
+
+    public function private()
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_private' => 1, // 鍵垢
+        ]);
     }
 
     public function admin()

--- a/kinoshita/practice-erd/instagram/laravel/database/migrations/2023_12_03_053439_add_basic_columns_to_users_table.php
+++ b/kinoshita/practice-erd/instagram/laravel/database/migrations/2023_12_03_053439_add_basic_columns_to_users_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->string('first_name');
             $table->string('icon_url');
             $table->integer('role_id')->default(0); // 0: ユーザー, 1: 管理者
+            $table->integer('is_private')->default(0); // 0: 鍵垢ではない, 1: 鍵垢
         });
     }
 
@@ -28,6 +29,7 @@ return new class extends Migration
             $table->dropColumn('last_name');
             $table->dropColumn('first_name');
             $table->dropColumn('icon_url');
+            $table->dropColumn('is_private');
         });
     }
 };

--- a/kinoshita/practice-erd/instagram/laravel/routes/api.php
+++ b/kinoshita/practice-erd/instagram/laravel/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\CommentController;
+use App\Http\Controllers\FollowController;
 use App\Http\Controllers\LikeController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\ProfileController;
@@ -41,3 +42,11 @@ Route::post(
 )->where('commentable_type', 'post|comment');
 
 Route::get('/profile/{user}', [ProfileController::class, 'show']);
+
+Route::group([
+    'prefix' => '/follow/{user}',
+    'controller' => FollowController::class,
+], function () {
+    Route::post('', 'store');
+    Route::delete('', 'destroy');
+});

--- a/kinoshita/practice-erd/instagram/laravel/routes/api.php
+++ b/kinoshita/practice-erd/instagram/laravel/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\LikeController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\ProfileController;
 use App\Models\Comment;
 use App\Models\Post;
 use Illuminate\Http\Request;
@@ -38,3 +39,5 @@ Route::post(
     '/comment/{commentable_type}/{commentable_id}', 
     [CommentController::class, 'create']
 )->where('commentable_type', 'post|comment');
+
+Route::get('/profile/{user}', [ProfileController::class, 'show']);

--- a/kinoshita/practice-erd/instagram/laravel/routes/api.php
+++ b/kinoshita/practice-erd/instagram/laravel/routes/api.php
@@ -7,7 +7,9 @@ use App\Http\Controllers\PostController;
 use App\Http\Controllers\ProfileController;
 use App\Models\Comment;
 use App\Models\Post;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -23,6 +25,12 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+Route::get('/login/{user}', function(User $user){
+    Auth::login($user);
+
+    return $user;
 });
 
 Route::apiResource('/post', PostController::class);

--- a/kinoshita/practice-erd/instagram/laravel/tests/Feature/PostControllerTest.php
+++ b/kinoshita/practice-erd/instagram/laravel/tests/Feature/PostControllerTest.php
@@ -3,13 +3,23 @@
 namespace Tests\Feature;
 
 use App\Models\Post;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Auth;
 use Tests\TestCase;
 
 class PostControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        Auth::login($user);
+    }
 
     /**
      * A basic feature test example.
@@ -76,6 +86,7 @@ class PostControllerTest extends TestCase
         $post = Post::factory()
             ->state([
                 'content' => 'initial content',
+                'user_id' => Auth::user()->id, // ログイン中のユーザーの投稿になるようにする
             ])
             ->hasComments()
             ->hasLikes()
@@ -110,6 +121,9 @@ class PostControllerTest extends TestCase
     {
         // データを作る
         $post = Post::factory()
+            ->state([
+                'user_id' => Auth::user()->id, // ログイン中のユーザーの投稿になるようにする
+            ])
             ->hasComments()
             ->hasLikes()
             ->hasTags()
@@ -134,6 +148,9 @@ class PostControllerTest extends TestCase
     {
         // データを作る
         $post = Post::factory()
+            ->state([
+                'user_id' => Auth::user()->id, // ログイン中のユーザーの投稿になるようにする
+            ])
             ->hasComments()
             ->hasLikes()
             ->hasTags()


### PR DESCRIPTION
# 内容

### 言語／フレームワーク
- [x] Laravel
- [ ] NextJs
- [ ] React＋Typescript
- [ ] Reactのみ

### 勉強時間（※大体でOK）

合計5時間

### 勉強内容

例：Controller作りました・データベースに接続を果たせました

- プロフィール画面
- フォロー機能
- 鍵垢（フォロワー以外はプロフィールを開いても投稿の写真がみれない）

#### プロフィール画面
- フォロー数、フォロワー数、投稿数、投稿の写真がみれる

<img width="200" src="https://github.com/StoryEdutech/study_repo/assets/81157639/a63e339e-5a87-4b31-aa90-e1e2c1b74caa" />

#### フォロー機能
- 「フォロー」を押したら、フォローできる

<img width="200" src="https://github.com/StoryEdutech/study_repo/assets/81157639/f43c137c-997f-4560-9e6d-e5b64c82b90a" />

#### 鍵垢
- フォローされているなら、プロフィールで投稿の写真がみれる
- されてない場合は「非公開」とでる

<img width="200" src="https://github.com/StoryEdutech/study_repo/assets/81157639/c7360331-1d4b-4621-92c1-de6f855a6d54" />

### 次勉強するもの
- 


# 感想
### 有用と思ったもの・意外だったもの
- Auth::login($user)というルートを作りました。ポストマンを使った検証でも認証の情報を保持できるようになったこと。
 - laravel移行の開発用の子供認証みたなものをできるようにしました

### 苦戦したもの
- テーブルにあるキーのアクセサーを作ってて、データの参照がおかしくなってた。気づくのに苦労しました

### 楽しかったもの（※任意）
- 今までは、ページ全体での認可というものしかやったことなかったですが、今回は部分的に認可を考えなければならなかったこと

